### PR TITLE
META | Append '- *' to 2018

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Lunar
+Copyright (c) 2018 - * Lunar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Instead of changing it every year, why not make it go until `*` year?